### PR TITLE
Fix bug in `optional` when field is present but doesn't decode

### DIFF
--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -33,4 +33,22 @@ all =
         |> decode """{"a":{},"x":{"y":"bar"}}"""
         |> assertEqual (Ok ( "--", "bar" ))
         |> test "should decode optionalAt fields"
+    , Pipeline.decode (,)
+        |> Pipeline.optional "a" Json.string "--"
+        |> Pipeline.optional "x" Json.string "--"
+        |> decode """{"x":"five"}"""
+        |> assertEqual (Ok ( "--", "five" ))
+        |> test "optional succeeds if the field is not present"
+    , Pipeline.decode (,)
+        |> Pipeline.optional "a" Json.string "--"
+        |> Pipeline.optional "x" Json.string "--"
+        |> decode """{"x":5}"""
+        |> assertEqual (Err "custom decoder failed: expecting a String but got 5")
+        |> test "optional fails if the field is present but doesn't decode"
+    , Pipeline.decode (,)
+        |> Pipeline.optionalAt [ "a", "b" ] Json.string "--"
+        |> Pipeline.optionalAt [ "x", "y" ] Json.string "--"
+        |> decode """{"a":{},"x":{"y":5}}"""
+        |> assertEqual (Err "custom decoder failed: expecting a String but got 5")
+        |> test "optionalAt fails if the field is present but doesn't decode"
     ]


### PR DESCRIPTION
This fixes the following scenario.
### Given

Using `optional` or `optionalAt` to decode an object where the requested field is a string, and the requested field is present but is not a string...
### Expected behavior

...the decoding operation should fail, because the field was present but did not decode.
### Actual behavior

...the decoding operation succeeds with the provided fallback. (This is because `optional` and `optionalAt` have been using [`Json.Decode.maybe`](http://package.elm-lang.org/packages/elm-lang/core/3.0.0/Json-Decode#maybe) under the hood, which translates any failed decoding - not just "field missing" - as equivalent.)
