### PR TITLE
Update for 0.17.  Resolves #6.

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -10,8 +10,7 @@
         "Json.Decode.Pipeline"
     ],
     "dependencies": {
-        "elm-lang/core": "3.0.0 <= v < 4.0.0",
-        "evancz/elm-effects": "2.0.1 <= v < 3.0.0"
+        "elm-lang/core": "4.0.0 <= v < 5.0.0"
     },
-    "elm-version": "0.16.0 <= v < 0.17.0"
+    "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/src/Json/Decode/Pipeline.elm
+++ b/src/Json/Decode/Pipeline.elm
@@ -1,4 +1,4 @@
-module Json.Decode.Pipeline (required, requiredAt, optional, optionalAt, resolveResult, decode, hardcoded, custom) where
+module Json.Decode.Pipeline exposing (required, requiredAt, optional, optionalAt, resolveResult, decode, hardcoded, custom)
 
 {-| ## Design Principles
 

--- a/tests/TestRunner.elm
+++ b/tests/TestRunner.elm
@@ -1,17 +1,8 @@
-module Main (..) where
+module Main exposing (..)
 
-import Signal exposing (Signal)
-import ElmTest exposing (consoleRunner)
-import Console exposing (IO, run)
-import Task
+import ElmTest exposing (..)
 import Tests
 
 
-console : IO ()
-console =
-  consoleRunner Tests.all
-
-
-port runner : Signal (Task.Task x ())
-port runner =
-  run console
+main =
+    runSuite Tests.all

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -1,4 +1,4 @@
-module Tests (..) where
+module Tests exposing (..)
 
 import ElmTest exposing (..)
 import String
@@ -43,12 +43,12 @@ all =
         |> Pipeline.optional "a" Json.string "--"
         |> Pipeline.optional "x" Json.string "--"
         |> decode """{"x":5}"""
-        |> assertEqual (Err "custom decoder failed: expecting a String but got 5")
+        |> assertEqual (Err "Expecting something custom but instead got: {\"x\":5}")
         |> test "optional fails if the field is present but doesn't decode"
     , Pipeline.decode (,)
         |> Pipeline.optionalAt [ "a", "b" ] Json.string "--"
         |> Pipeline.optionalAt [ "x", "y" ] Json.string "--"
         |> decode """{"a":{},"x":{"y":5}}"""
-        |> assertEqual (Err "custom decoder failed: expecting a String but got 5")
+        |> assertEqual (Err "Expecting something custom but instead got: {\"a\":{},\"x\":{\"y\":5}}")
         |> test "optionalAt fails if the field is present but doesn't decode"
     ]

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -9,9 +9,8 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "deadfoxygrandpa/elm-test": "3.0.0 <= v < 4.0.0",
-        "elm-lang/core": "2.0.0 <= v < 4.0.0",
-        "laszlopandy/elm-console": "1.0.1 <= v < 2.0.0"
+        "elm-community/elm-test": "1.0.0 <= v < 2.0.0",
+        "elm-lang/core": "3.0.0 <= v < 4.0.0"
     },
-    "elm-version": "0.15.0 <= v < 0.17.0"
+    "elm-version": "0.17.0 <= v < 0.18.0"
 }


### PR DESCRIPTION
The only real change is that JSON decoders now give a slightly
more detailed message on failure, so the tests must expect a different string.

It's not clear to me how use of the console in tests is updated for 0.17; some of the documentation in elm-test still refers to `laszlopandy/elm-console` and some doesn't.  I ran the tests by compiling to HTML, and they passed.
