### PR TITLE
Reimplement some functions in a more concise way

### DIFF
--- a/src/Json/Decode/Pipeline.elm
+++ b/src/Json/Decode/Pipeline.elm
@@ -237,7 +237,7 @@ to perform some custom processing just before completing the decoding operation.
 -}
 resolveResult : Decoder (Result String a) -> Decoder a
 resolveResult resultDecoder =
-  andThen resultDecoder (\result -> customDecoder (succeed ()) (\_ -> result))
+  customDecoder resultDecoder identity
 
 
 {-| Begin a decoding pipeline. This is a synonym for [Json.Decode.succeed](http://package.elm-lang.org/packages/elm-lang/core/3.0.0/Json-Decode#succeed),

--- a/src/Json/Decode/Pipeline.elm
+++ b/src/Json/Decode/Pipeline.elm
@@ -9,7 +9,7 @@ module Json.Decode.Pipeline exposing (required, requiredAt, optional, optionalAt
 @docs required, requiredAt, optional, optionalAt, hardcoded, custom, resolveResult, decode
 -}
 
-import Json.Decode exposing (Decoder, map, succeed, andThen, (:=), maybe, customDecoder)
+import Json.Decode exposing (Decoder, map, object2, succeed, andThen, (:=), maybe, customDecoder)
 
 
 {-| Decode a required field.
@@ -148,8 +148,8 @@ pipeline. `harcoded` does not look at the JSON at all.
     -- Ok { id = 123, email = "sam@example.com", followers = 0 }
 -}
 hardcoded : a -> Decoder (a -> b) -> Decoder b
-hardcoded val decoder =
-  andThen decoder (\wrappedFn -> map wrappedFn (succeed val))
+hardcoded =
+  succeed >> custom
 
 
 {-| Run the given decoder and feed its result into the pipeline at this point.
@@ -189,8 +189,8 @@ Consider this example.
     -- Ok { id = 123, name = "Sam", email = "sam@example.com" }
 -}
 custom : Decoder a -> Decoder (a -> b) -> Decoder b
-custom delegated decoder =
-  andThen decoder (\wrappedFn -> map wrappedFn delegated)
+custom =
+  object2 (|>)
 
 
 {-| Convert a `Decoder (Result x a)` into a `Decoder a`. Useful when you want

--- a/src/Json/Decode/Pipeline.elm
+++ b/src/Json/Decode/Pipeline.elm
@@ -9,7 +9,7 @@ module Json.Decode.Pipeline exposing (required, requiredAt, optional, optionalAt
 @docs required, requiredAt, optional, optionalAt, hardcoded, custom, resolveResult, decode
 -}
 
-import Json.Decode exposing (Decoder, map, object2, succeed, andThen, (:=), maybe, customDecoder)
+import Json.Decode exposing (Decoder, map, object2, succeed, (:=), maybe, customDecoder)
 
 
 {-| Decode a required field.

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -51,4 +51,16 @@ all =
         |> decode """{"a":{},"x":{"y":5}}"""
         |> assertEqual (Err "Expecting something custom but instead got: {\"a\":{},\"x\":{\"y\":5}}")
         |> test "optionalAt fails if the field is present but doesn't decode"
+    , Pipeline.decode Err
+        |> Pipeline.required "error" Json.string
+        |> Pipeline.resolveResult
+        |> decode """{"error":"invalid"}"""
+        |> assertEqual (Err "A `customDecode` failed with the message: invalid")
+        |> test "resolveResult bubbles up decoded Err results"
+    , Pipeline.decode Ok
+        |> Pipeline.required "ok" Json.string
+        |> Pipeline.resolveResult
+        |> decode """{"ok":"valid"}"""
+        |> assertEqual (Ok "valid")
+        |> test "resolveResult bubbles up decoded Ok results"
     ]


### PR DESCRIPTION
For your consideration...

I saw a few opportunities to write things a bit more concisely, and without using `andThen` which is more powerful a function than necessary for these cases. I structured the commits so that you should be able to easily cherry-pick what you like and leave what you don't like. I'm also happy to make modifications based on feedback.

I recognize that the point-free style that I used for `hardcoded` and `custom` is perhaps a bit extreme and not to everyone's taste. They could be rewritten in various ways such as making the arguments explicit, and/or using local definitions like `map2 = object2` or `andMap = object2 (<|)`. Of course you may still like the original `andThen` versions better. I think that the implementation I've provided for `resolveResult` is a more clear improvement with less potential for controversy :)

If you don't want to merge any of these rewritten functions, I would suggest that the tests I added for `resolveResult` are probably still a good addition. The `Err` test assumes the latest `customDecode` error message format, as in #11.

Cheers,
James
