### PR TITLE
Allow optional valDecoder a chance to decode nulls its own way

### DIFF
--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -1,8 +1,19 @@
-module Main exposing (..)
+port module Main exposing (..)
 
-import ElmTest exposing (..)
+{-|
+Run the tests with node-test-runner:
+
+https://github.com/rtfeldman/node-test-runner
+-}
+
 import Tests
+import Test.Runner.Node exposing (run)
+import Json.Encode exposing (Value)
 
 
+main : Program Never
 main =
-    runSuite Tests.all
+    run emit Tests.all
+
+
+port emit : ( String, Value ) -> Cmd msg

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -1,6 +1,7 @@
 module Tests exposing (..)
 
-import ElmTest exposing (..)
+import Test exposing (..)
+import Expect
 import String
 import Json.Decode.Pipeline as Pipeline
 import Json.Decode as Json
@@ -13,60 +14,69 @@ decode =
 
 all : Test
 all =
-    suite
+    describe
         "Json.Decode.Pipeline"
         [ Pipeline.decode (,)
             |> Pipeline.required "a" Json.string
             |> Pipeline.required "b" Json.string
             |> decode """{"a":"foo","b":"bar"}"""
-            |> assertEqual (Ok ( "foo", "bar" ))
+            |> Expect.equal (Ok ( "foo", "bar" ))
+            |> always
             |> test "should decode basic example"
         , Pipeline.decode (,)
             |> Pipeline.requiredAt [ "a" ] Json.string
             |> Pipeline.requiredAt [ "b", "c" ] Json.string
             |> decode """{"a":"foo","b":{"c":"bar"}}"""
-            |> assertEqual (Ok ( "foo", "bar" ))
+            |> Expect.equal (Ok ( "foo", "bar" ))
+            |> always
             |> test "should decode requiredAt fields"
         , Pipeline.decode (,)
             |> Pipeline.optionalAt [ "a", "b" ] Json.string "--"
             |> Pipeline.optionalAt [ "x", "y" ] Json.string "--"
             |> decode """{"a":{},"x":{"y":"bar"}}"""
-            |> assertEqual (Ok ( "--", "bar" ))
+            |> Expect.equal (Ok ( "--", "bar" ))
+            |> always
             |> test "should decode optionalAt fields"
         , Pipeline.decode (,)
             |> Pipeline.optional "a" Json.string "--"
             |> Pipeline.optional "x" Json.string "--"
             |> decode """{"x":"five"}"""
-            |> assertEqual (Ok ( "--", "five" ))
+            |> Expect.equal (Ok ( "--", "five" ))
+            |> always
             |> test "optional succeeds if the field is not present"
         , Pipeline.decode (,)
             |> Pipeline.optional "a" Json.string "--"
             |> Pipeline.optional "x" Json.string "--"
             |> decode """{"a":null,"x":"five"}"""
-            |> assertEqual (Ok ( "--", "five" ))
+            |> Expect.equal (Ok ( "--", "five" ))
+            |> always
             |> test "optional succeeds if the field is present but null"
         , Pipeline.decode (,)
             |> Pipeline.optional "a" Json.string "--"
             |> Pipeline.optional "x" Json.string "--"
             |> decode """{"x":5}"""
-            |> assertEqual (Err "A `customDecode` failed with the message: Expecting a String but instead got: 5")
+            |> Expect.equal (Err "A `customDecode` failed with the message: Expecting a String but instead got: 5")
+            |> always
             |> test "optional fails if the field is present but doesn't decode"
         , Pipeline.decode (,)
             |> Pipeline.optionalAt [ "a", "b" ] Json.string "--"
             |> Pipeline.optionalAt [ "x", "y" ] Json.string "--"
             |> decode """{"a":{},"x":{"y":5}}"""
-            |> assertEqual (Err "A `customDecode` failed with the message: Expecting a String but instead got: 5")
+            |> Expect.equal (Err "A `customDecode` failed with the message: Expecting a String but instead got: 5")
+            |> always
             |> test "optionalAt fails if the field is present but doesn't decode"
         , Pipeline.decode Err
             |> Pipeline.required "error" Json.string
             |> Pipeline.resolveResult
             |> decode """{"error":"invalid"}"""
-            |> assertEqual (Err "A `customDecode` failed with the message: invalid")
+            |> Expect.equal (Err "A `customDecode` failed with the message: invalid")
+            |> always
             |> test "resolveResult bubbles up decoded Err results"
         , Pipeline.decode Ok
             |> Pipeline.required "ok" Json.string
             |> Pipeline.resolveResult
             |> decode """{"ok":"valid"}"""
-            |> assertEqual (Ok "valid")
+            |> Expect.equal (Ok "valid")
+            |> always
             |> test "resolveResult bubbles up decoded Ok results"
         ]

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -63,7 +63,14 @@ all =
             |> decode """{"a":null,"x":"five"}"""
             |> Expect.equal (Ok ( "--", "five" ))
             |> always
-            |> test "optional succeeds if the field is present but null"
+            |> test "optional succeeds with fallback if the field is present but null"
+        , Pipeline.decode (,)
+            |> Pipeline.optional "a" (Json.null "null") "--"
+            |> Pipeline.optional "x" Json.string "--"
+            |> decode """{"a":null,"x":"five"}"""
+            |> Expect.equal (Ok ( "null", "five" ))
+            |> always
+            |> test "optional succeeds with result of the given decoder if the field is null and the decoder decodes nulls"
         , Pipeline.decode (,)
             |> Pipeline.optional "a" Json.string "--"
             |> Pipeline.optional "x" Json.string "--"

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -9,8 +9,9 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-community/elm-test": "1.0.0 <= v < 2.0.0",
-        "elm-lang/core": "3.0.0 <= v < 4.0.0"
+        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
+        "rtfeldman/node-test-runner": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"
 }


### PR DESCRIPTION
First two commits are from #15.

This PR changes the implementation of `optional` to try the given `valDecoder` before resorting to the `null` decoder for the fallback. The previous behavior was that a `null` value would always decode as `fallback`, whether or not `valDecoder` could successfully decode nulls. The new behavior here means that you can use `optional` and still distinguish between `null` values and missing fields if necessary.

@rtfeldman 
