### PR TITLE
Upgrade to 0.18

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.0",
+    "version": "3.0.0",
     "summary": "A pipeline-friendly library for building JSON decoders.",
     "repository": "https://github.com/NoRedInk/elm-decode-pipeline.git",
     "license": "BSD-3-Clause",
@@ -10,7 +10,7 @@
         "Json.Decode.Pipeline"
     ],
     "dependencies": {
-        "elm-lang/core": "4.0.0 <= v < 5.0.0"
+        "elm-lang/core": "5.0.0 <= v < 6.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/src/Json/Decode/Pipeline.elm
+++ b/src/Json/Decode/Pipeline.elm
@@ -6,7 +6,7 @@ Use the `(|>)` operator to build JSON decoders.
 
 ## Decoding fields
 
-@docs required, requiredAt, optional, optionalAt, hardcoded, custom, nullable
+@docs required, requiredAt, optional, optionalAt, hardcoded, custom
 
 ## Beginning and ending pipelines
 
@@ -284,44 +284,3 @@ intended to make things read more clearly.
 decode : a -> Decoder a
 decode =
     succeed
-
-
-{-| Extract a value that might be `null`.
-
-If the value is `null`, decodes to `Nothing`.
-If the value is not `null`, runs the given decoder on it and...
-
-* ...If that decoder succeeds, wraps its success value in a `Just`.
-* ...If it fails, the entire decoding operation fails.
-
-
-    import Json.Decode exposing (int, string, float, Decoder)
-    import Json.Decode.Pipeline exposing (decode, required, optional)
-
-
-    type alias User =
-      { id : Int
-      , email : String
-      , name : Maybe String
-      }
-
-
-    userDecoder : Decoder User
-    userDecoder =
-      decode User
-        |> required "id" int
-        |> required "email" string
-        |> required "name" (nullable string)
-
-In the above example,
-
-* If `name` is `null`, it will successfully decode to `Nothing`
-* If `name` is `"Lee"` it will successfully decode to `Just "Lee"`
-* If `name` is not present, the whole decoder will fail.
--}
-nullable : Decoder a -> Decoder (Maybe a)
-nullable decoder =
-    Json.Decode.oneOf
-        [ Json.Decode.null Nothing
-        , Json.Decode.map Just decoder
-        ]

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -9,9 +9,9 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-lang/core": "4.0.0 <= v < 5.0.0",
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-community/elm-test": "2.0.0 <= v < 3.0.0",
         "rtfeldman/node-test-runner": "1.0.0 <= v < 2.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }


### PR DESCRIPTION
## Still TODO

- [ ] Upgrade tests once elm-test for 0.18 lands

## Breaking Changes

* Removed `nullable` since [that function is in `Json.Decode`](http://package.elm-lang.org:8018/packages/elm-lang/core/5.0.0/Json-Decode#nullable) as of core v5.
* Changed `resolveResult : Decoder (Result String a) -> Decoder a` to `resolve : Decoder (Decoder a) -> Decoder a` to keep consistent with how `Json.Decode` now works exclusively in terms of decoders (via `andThen`) instead of in terms of `Result`.
